### PR TITLE
✏️ :: Fix invalid URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Once you have your Swift package set up, adding SushiBelt as a dependency is as 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com:daangn/SushiBelt.git", .upToNextMajor(from: "1.0.0"))
+    .package(url: "https://github.com/daangn/SushiBelt.git", .upToNextMajor(from: "1.0.0"))
 ]
 ```
 


### PR DESCRIPTION
README에 있던
https://github.com/daangn/SushiBelt/blob/a76095c471fd8fc26757e566a624b6b1e47aefaa/README.md?plain=1#L146-L148
부분의 url이 약간 이상하길래 수정했습니다.


- https://github.com:daangn/SushiBelt.git -> https://github.com/daangn/SushiBelt.git