### PR TITLE
chore: SushiBeltTrackerItem+Extension typo

### DIFF
--- a/Sources/SushiBelt/SushiBeltTrakerItem+Extension.swift
+++ b/Sources/SushiBelt/SushiBeltTrakerItem+Extension.swift
@@ -11,14 +11,14 @@ import Foundation
 
 extension SushiBeltTrackerItem {
   
-  func currentVisibleRatioPersentageString() -> String {
+  func currentVisibleRatioPercentageString() -> String {
     return String(
       format: "%.2f",
       self.currentVisibleRatio * 100
     ) + "%"
   }
   
-  func objectiveVisibleRatioPersentageString() -> String {
+  func objectiveVisibleRatioPercentageString() -> String {
     return String(
       format: "%.2f",
       self.objectiveVisibleRatio * 100
@@ -26,7 +26,7 @@ extension SushiBeltTrackerItem {
   }
   
   func defaultDescirption() -> String {
-    return "\(self.currentVisibleRatioPersentageString())\nObjective: \(self.objectiveVisibleRatioPersentageString())"
+    return "\(self.currentVisibleRatioPercentageString())\nObjective: \(self.objectiveVisibleRatioPercentageString())"
   }
   
 }


### PR DESCRIPTION
- Fixed a typo in the [SushiBeltTrackerItem+Extension](https://github.com/daangn/SushiBelt/blob/develop/Sources/SushiBelt/SushiBeltTrakerItem%2BExtension.swift) file.
    - **PersentageString** → **PercentageString**