### PR TITLE
feat!: symmetric threshold tracking with didEnter/didExit

### DIFF
--- a/Example/SushiBelt.xcodeproj/project.pbxproj
+++ b/Example/SushiBelt.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		630220CA2917A86100BB52BB /* Sushi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630220C92917A86100BB52BB /* Sushi.swift */; };
 		630220CC2917AE0D00BB52BB /* MainTestKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630220CB2917AE0D00BB52BB /* MainTestKind.swift */; };
 		6357DDEE2BF59B82002CF46F /* MatrixViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357DDED2BF59B82002CF46F /* MatrixViewController.swift */; };
+		630220C92026060800BB52BB /* SymmetricListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630220C82026060800BB52BB /* SymmetricListViewController.swift */; };
 		64124CB3B1A70B8895D6CFC3 /* Pods_SushiBelt_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 549A69A85E1A3E5CDD18BAB3 /* Pods_SushiBelt_Tests.framework */; };
 		96837B9D5AAEC5191BD928C6 /* Pods_SushiBelt_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9582B77D1A71BE86C93C42A2 /* Pods_SushiBelt_Example.framework */; };
 /* End PBXBuildFile section */
@@ -47,6 +48,7 @@
 		630220C92917A86100BB52BB /* Sushi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sushi.swift; sourceTree = "<group>"; };
 		630220CB2917AE0D00BB52BB /* MainTestKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTestKind.swift; sourceTree = "<group>"; };
 		6357DDED2BF59B82002CF46F /* MatrixViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixViewController.swift; sourceTree = "<group>"; };
+		630220C82026060800BB52BB /* SymmetricListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymmetricListViewController.swift; sourceTree = "<group>"; };
 		75900424683F94C20A7CCC6A /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		842B83AA3961CCC887E18551 /* Pods-SushiBelt_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SushiBelt_Tests.release.xcconfig"; path = "Target Support Files/Pods-SushiBelt_Tests/Pods-SushiBelt_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		9582B77D1A71BE86C93C42A2 /* Pods_SushiBelt_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SushiBelt_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -118,6 +120,7 @@
 				630220C22917A7FB00BB52BB /* SingleListViewController.swift */,
 				630220C42917A80100BB52BB /* ScrollViewController.swift */,
 				6357DDED2BF59B82002CF46F /* MatrixViewController.swift */,
+				630220C82026060800BB52BB /* SymmetricListViewController.swift */,
 				630220C62917A83000BB52BB /* TileListViewController.swift */,
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
@@ -353,6 +356,7 @@
 			files = (
 				630220CA2917A86100BB52BB /* Sushi.swift in Sources */,
 				6357DDEE2BF59B82002CF46F /* MatrixViewController.swift in Sources */,
+				630220C92026060800BB52BB /* SymmetricListViewController.swift in Sources */,
 				630220C12917A7EE00BB52BB /* MainViewController.swift in Sources */,
 				630220CC2917AE0D00BB52BB /* MainTestKind.swift in Sources */,
 				630220C52917A80100BB52BB /* ScrollViewController.swift in Sources */,

--- a/Example/SushiBelt/MainTestKind.swift
+++ b/Example/SushiBelt/MainTestKind.swift
@@ -14,6 +14,7 @@ enum MainTestKind: Int, CaseIterable {
   case scroll
   case tile
   case matrix
+  case symmetric
 
   var image: UIImage? {
     switch self {
@@ -25,6 +26,8 @@ enum MainTestKind: Int, CaseIterable {
       return UIImage(named: "egg_sushi")
     case .matrix:
       return UIImage(named: "red_sushi")
+    case .symmetric:
+      return UIImage(named: "orange_sushi")
     }
   }
 
@@ -38,6 +41,8 @@ enum MainTestKind: Int, CaseIterable {
       return 0.8
     case .matrix:
       return 0.2
+    case .symmetric:
+      return 0.5
     }
   }
 
@@ -51,6 +56,8 @@ enum MainTestKind: Int, CaseIterable {
       return "Tile List"
     case .matrix:
       return "Matrix"
+    case .symmetric:
+      return "Symmetric"
     }
   }
 }

--- a/Example/SushiBelt/MainViewController.swift
+++ b/Example/SushiBelt/MainViewController.swift
@@ -149,6 +149,12 @@ extension MainViewController: UICollectionViewDelegate, UICollectionViewDelegate
         MatrixViewController(),
         animated: true
       )
+
+    case .symmetric:
+      self.navigationController?.pushViewController(
+        SymmetricListViewController(),
+        animated: true
+      )
     }
   }
 

--- a/Example/SushiBelt/MainViewController.swift
+++ b/Example/SushiBelt/MainViewController.swift
@@ -202,7 +202,7 @@ extension MainViewController: SushiBeltTrackerDelegate {
     print("🚀 begin tracking: \(item.debugDescription)")
   }
 
-  func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+  func didEnter(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
 
     print("🎯 tracked: \(item.debugDescription)")
   }

--- a/Example/SushiBelt/MatrixViewController.swift
+++ b/Example/SushiBelt/MatrixViewController.swift
@@ -151,7 +151,7 @@ extension MatrixViewController: SushiBeltTrackerDelegate {
     print("🚀 begin tracking: \(item.debugDescription)")
   }
 
-  func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+  func didEnter(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
 
     print("🎯 tracked: \(item.debugDescription)")
   }

--- a/Example/SushiBelt/ScrollViewController.swift
+++ b/Example/SushiBelt/ScrollViewController.swift
@@ -150,7 +150,7 @@ extension ScrollViewController: SushiBeltTrackerDelegate {
     print("🚀 begin tracking: \(item.debugDescription)")
   }
 
-  func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+  func didEnter(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
 
     print("🎯 tracked: \(item.debugDescription)")
   }

--- a/Example/SushiBelt/SingleListViewController.swift
+++ b/Example/SushiBelt/SingleListViewController.swift
@@ -152,7 +152,7 @@ extension SingleListViewController: SushiBeltTrackerDelegate {
     print("🚀 begin tracking: \(item.debugDescription)")
   }
 
-  func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+  func didEnter(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
 
     print("🎯 tracked: \(item.debugDescription)")
   }

--- a/Example/SushiBelt/SymmetricListViewController.swift
+++ b/Example/SushiBelt/SymmetricListViewController.swift
@@ -1,0 +1,178 @@
+//
+//  SymmetricListViewController.swift
+//  SushiBelt_Example
+//
+//  Demonstrates symmetric threshold tracking via the `tracksDismiss` opt-in.
+//  Each item registers with `tracksDismiss: true`, so the tracker fires
+//  `didDismiss(_:item:)` when the item drops below the threshold while
+//  staying in the visible set, and re-fires `didTrack(_:item:)` when it
+//  crosses back up.
+//
+//  Scroll the list and watch the console for:
+//    🎯 tracked      — ratio crossed ≥ threshold (start of a visible session)
+//    💤 dismissed    — ratio dropped < threshold or item left the set
+//                      (end of the visible session, paired with the prior 🎯)
+//    🚀 begin / 👋 end  — existing set lifecycle callbacks
+//
+
+import UIKit
+
+import SushiBelt
+
+final class SymmetricListTestCell: UICollectionViewCell {
+
+  static let identifier = "SymmetricListTestCell"
+
+  private let imageView = UIImageView()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    self.contentView.addSubview(self.imageView)
+    self.contentView.backgroundColor = UIColor(red: 1.0, green: 0.83, blue: 0.47, alpha: 1.0)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    self.imageView.image = nil
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    self.imageView.frame.size = CGSize(width: 200.0, height: 200.0)
+    self.imageView.center = self.contentView.center
+    self.contentView.layer.cornerRadius = 24.0
+  }
+
+  func configure(sushi: Sushi) {
+    self.imageView.image = sushi.image
+  }
+}
+
+class SymmetricListViewController: UIViewController {
+
+  /// Fixed threshold for this demo so the symmetric crossing point is easy
+  /// to reason about while scrolling.
+  private static let visibleThreshold: CGFloat = 0.5
+
+  private let collectionView: UICollectionView = {
+    let layout = UICollectionViewFlowLayout()
+    layout.scrollDirection = .vertical
+    layout.minimumLineSpacing = 0.0
+    layout.minimumInteritemSpacing = 0.0
+    let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
+    view.backgroundColor = .white
+    view.register(SymmetricListTestCell.self, forCellWithReuseIdentifier: SymmetricListTestCell.identifier)
+    return view
+  }()
+
+  private let tracker = SushiBeltTracker()
+  private let debugger = SushiBeltDebugger.shared
+
+  private let sushis = Sushi.いらっしゃいませ(count: 200)
+
+  override func loadView() {
+    self.view = self.collectionView
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.title = "Symmetric"
+    self.view.backgroundColor = UIColor.systemBackground
+    self.tracker.delegate = self
+    self.tracker.dataSource = self
+    self.tracker.registerDebugger(debugger: self.debugger)
+    self.debugger.show()
+    self.collectionView.delegate = self
+    self.collectionView.dataSource = self
+  }
+
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    self.trackingVisibleCellsIfNeeded()
+  }
+
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    self.tracker.calculateItemsIfNeeded(items: [])
+  }
+}
+
+extension SymmetricListViewController: UICollectionViewDataSource {
+
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return self.sushis.count
+  }
+
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SymmetricListTestCell.identifier, for: indexPath) as? SymmetricListTestCell else {
+      fatalError()
+    }
+    let sushi = self.sushis[indexPath.item]
+    cell.configure(sushi: sushi)
+    return cell
+  }
+
+}
+
+extension SymmetricListViewController: UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
+
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    return CGSize(width: collectionView.bounds.width, height: 300.0)
+  }
+
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    return 24.0
+  }
+
+  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    self.trackingVisibleCellsIfNeeded()
+  }
+
+  private func trackingVisibleCellsIfNeeded() {
+    let trackingItems = self.collectionView.visibleCells.compactMap { cell -> SushiBeltTrackerItem? in
+      guard let indexPath = self.collectionView.indexPath(for: cell) else { return nil }
+
+      return SushiBeltTrackerItem(
+        id: .indexPath(indexPath),
+        rect: cell.sushiBeltTrackerItemRect(),
+        tracksDismiss: true
+      )
+    }
+    self.tracker.calculateItemsIfNeeded(items: trackingItems)
+  }
+
+}
+
+extension SymmetricListViewController: SushiBeltTrackerDataSource {
+
+  func trackingRect(_ tracker: SushiBeltTracker) -> CGRect {
+    return self.collectionView.frame
+  }
+
+  func visibleRatioForItem(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) -> CGFloat {
+    return SymmetricListViewController.visibleThreshold
+  }
+}
+
+extension SymmetricListViewController: SushiBeltTrackerDelegate {
+
+  func willBeginTracking(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    print("🚀 begin tracking: \(item.debugDescription)")
+  }
+
+  func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    print("🎯 tracked: \(item.debugDescription)")
+  }
+
+  func didDismiss(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    print("💤 dismissed: \(item.debugDescription)")
+  }
+
+  func didEndTracking(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    print("👋 end tracking: \(item.debugDescription)")
+  }
+}

--- a/Example/SushiBelt/SymmetricListViewController.swift
+++ b/Example/SushiBelt/SymmetricListViewController.swift
@@ -2,16 +2,16 @@
 //  SymmetricListViewController.swift
 //  SushiBelt_Example
 //
-//  Demonstrates symmetric threshold tracking via the `tracksDismiss` opt-in.
-//  Each item registers with `tracksDismiss: true`, so the tracker fires
-//  `didDismiss(_:item:)` when the item drops below the threshold while
-//  staying in the visible set, and re-fires `didTrack(_:item:)` when it
+//  Demonstrates symmetric threshold tracking via the `tracksExit` opt-in.
+//  Each item registers with `tracksExit: true`, so the tracker fires
+//  `didExit(_:item:)` when the item drops below the threshold while
+//  staying in the visible set, and re-fires `didEnter(_:item:)` when it
 //  crosses back up.
 //
 //  Scroll the list and watch the console for:
-//    🎯 tracked      — ratio crossed ≥ threshold (start of a visible session)
-//    💤 dismissed    — ratio dropped < threshold or item left the set
-//                      (end of the visible session, paired with the prior 🎯)
+//    🎯 enter       — ratio crossed ≥ threshold (start of a visible session)
+//    🚪 exit        — ratio dropped < threshold or item left the set
+//                     (end of the visible session, paired with the prior 🎯)
 //    🚀 begin / 👋 end  — existing set lifecycle callbacks
 //
 
@@ -139,7 +139,7 @@ extension SymmetricListViewController: UICollectionViewDelegate, UICollectionVie
       return SushiBeltTrackerItem(
         id: .indexPath(indexPath),
         rect: cell.sushiBeltTrackerItemRect(),
-        tracksDismiss: true
+        tracksExit: true
       )
     }
     self.tracker.calculateItemsIfNeeded(items: trackingItems)
@@ -164,12 +164,12 @@ extension SymmetricListViewController: SushiBeltTrackerDelegate {
     print("🚀 begin tracking: \(item.debugDescription)")
   }
 
-  func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
-    print("🎯 tracked: \(item.debugDescription)")
+  func didEnter(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    print("🎯 enter: \(item.debugDescription)")
   }
 
-  func didDismiss(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
-    print("💤 dismissed: \(item.debugDescription)")
+  func didExit(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    print("🚪 exit: \(item.debugDescription)")
   }
 
   func didEndTracking(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {

--- a/Example/SushiBelt/TileListViewController.swift
+++ b/Example/SushiBelt/TileListViewController.swift
@@ -149,7 +149,7 @@ extension TileListViewController: SushiBeltTrackerDelegate {
     print("🚀 begin tracking: \(item.debugDescription)")
   }
 
-  func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+  func didEnter(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
 
     print("🎯 tracked: \(item.debugDescription)")
   }

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,90 @@
+# Migration Guide
+
+## 2.x → 3.0
+
+SushiBelt 3.0 introduces **symmetric threshold tracking** (an opt-in
+`didExit` down-crossing callback) and, to make the delegate API symmetric,
+renames the existing up-crossing callback `didTrack` to `didEnter`.
+
+The rename is the **only** breaking change. Everything else in 3.0 is additive
+and requires no action unless you opt in.
+
+### What changed
+
+| 2.x | 3.0 | Kind |
+|---|---|---|
+| `func didTrack(_:item:)` | `func didEnter(_:item:)` | **Breaking** — renamed |
+| — | `func didExit(_:item:)` | Additive — optional (default no-op) |
+| — | `SushiBeltTrackerItem(…, tracksExit:)` | Additive — new init parameter, defaults to `false` |
+
+### Why `didTrack` was renamed
+
+The new callback fires when an item's visible ratio crosses **down** below the
+threshold while the item is still in the tracked set. Naming it as the opposite
+of `didTrack` was awkward — `track` has no natural antonym, and candidates like
+`dismiss`/`exit` collided with unrelated concepts (`UIViewController.dismiss`,
+the set-membership callback `didEndTracking`).
+
+SushiBelt has two independent axes:
+
+| Axis | Enters | Leaves |
+|---|---|---|
+| **Set membership** | `willBeginTracking` | `didEndTracking` |
+| **Visibility threshold** | `didEnter` (was `didTrack`) | `didExit` (new) |
+
+`didEnter` / `didExit` form a clean symmetric pair on the threshold axis, and
+the `…Tracking` suffix keeps the membership callbacks visually distinct. When
+`didExit` fires, the item is still in the set — only its visible ratio dropped
+below the threshold (`isTracked: true → false`).
+
+### How to migrate
+
+Rename your delegate method. The signature and firing semantics are identical —
+only the name changed:
+
+```diff
+  extension SomeObject: SushiBeltTrackerDelegate {
+
+-   func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
++   func didEnter(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+      // unchanged body
+    }
+  }
+```
+
+`didEnter` is a required protocol method with no default implementation, so the
+compiler flags every conformance that still defines `didTrack`. There is no
+silent behavior change — build errors surface every call site.
+
+### Nothing else required
+
+- Existing **sticky** tracking is unchanged. Items still fire `didEnter` once on
+  the first up-crossing and stay tracked until they leave the set.
+- `didExit` and `tracksExit` are opt-in. You only touch them when you want
+  symmetric "above/below threshold" signaling (e.g. viewable-impression
+  start/end pairs, time-in-view).
+
+### Opting into symmetric tracking (optional)
+
+```swift
+let item = SushiBeltTrackerItem(
+  id: .index(0),
+  rect: someRect,
+  tracksExit: true
+)
+
+extension SomeObject: SushiBeltTrackerDelegate {
+
+  func didEnter(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    // ratio crossed up — start of a visible session
+  }
+
+  func didExit(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    // ratio crossed down, OR the item left the set while above threshold
+    // — end of the visible session, paired with the prior didEnter
+  }
+}
+```
+
+`tracksExit` is per-item, so a single tracker can freely mix sticky and
+symmetric items.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Also, SushiBelt calculates visible ratio as the scroll direction changes.
 - [x] Support a measurement of exposure ratio for each view.
 - [x] Support a various item identifiers such as integer index, IndexPath, and user-defined identifier.
 - [x] Visibility Debugger.
-- [x] Symmetric threshold tracking — opt-in per-item `didDismiss` callback for down-crossings, paired with the existing `didTrack` for start/end signal modeling.
+- [x] Symmetric threshold tracking — opt-in per-item `didExit` callback for down-crossings, paired with `didEnter` for start/end signal modeling.
 
 ## Basic usages
 
@@ -67,6 +67,10 @@ extension SomeObject: SushiBeltTrackerDelegate {
   
   func willBeginTracking(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
     // begin tracking
+  }
+
+  func didEnter(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    // ratio crossed up to meet the threshold
   }
   
   func didEndTracking(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
@@ -105,33 +109,38 @@ let tracker = SushiBeltTracker(
 )
 ```
 
-### Symmetric threshold tracking with `tracksDismiss`
+### Symmetric threshold tracking with `tracksExit`
 
-By default, items follow the sticky model: `didTrack` fires once when the ratio first crosses the threshold, and `isTracked` stays `true` until the item leaves the visible set.
+By default, items follow the sticky model: `didEnter` fires once when the ratio first crosses the threshold, and `isTracked` stays `true` until the item leaves the visible set.
 
-For symmetric "above/below" signaling (e.g. viewable impression start/end pairs, time-in-view), register items with `tracksDismiss: true`. The tracker then re-evaluates the ratio every tick and fires a `didDismiss` callback whenever the ratio drops below the threshold — pairing naturally with `didTrack` on subsequent up-crossings.
+For symmetric "above/below" signaling (e.g. viewable impression start/end pairs, time-in-view), register items with `tracksExit: true`. The tracker then re-evaluates the ratio every tick and fires a `didExit` callback whenever the ratio drops below the threshold — pairing naturally with `didEnter` on subsequent up-crossings.
 
 ```swift
 let item = SushiBeltTrackerItem(
   id: .index(0),
   rect: someRect,
-  tracksDismiss: true
+  tracksExit: true
 )
 
 extension SomeObject: SushiBeltTrackerDelegate {
 
-  func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+  func didEnter(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
     // ratio crossed up — start of a visible session
   }
 
-  func didDismiss(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+  func didExit(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
     // ratio crossed down, OR the item left the set while above threshold
-    // — end of the visible session, paired with the prior didTrack
+    // — end of the visible session, paired with the prior didEnter
   }
 }
 ```
 
-`didDismiss` has a default no-op via protocol extension, so existing delegate conformances remain source-compatible. The flag is per-item, so a single tracker can mix sticky and symmetric items.
+`didExit` has a default no-op via protocol extension, so existing delegate conformances remain source-compatible. The flag is per-item, so a single tracker can mix sticky and symmetric items.
+
+## Migration
+
+Upgrading from 2.x to 3.0 renames one delegate method (`didTrack` → `didEnter`).
+See [MIGRATION.md](./MIGRATION.md) for the full guide.
 
 ### VisibleRatioCalculator
 Default visible ratio clculator will calculate with CGRect.intersection with scrollDirection. If you wanna make a custom visible ratio calculation logics. you can make a custom visible ratio calculator with SushiBeltTrackerItemDiffChecker interface. you just inherts it!

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Also, SushiBelt calculates visible ratio as the scroll direction changes.
 - [x] Support a measurement of exposure ratio for each view.
 - [x] Support a various item identifiers such as integer index, IndexPath, and user-defined identifier.
 - [x] Visibility Debugger.
+- [x] Symmetric threshold tracking — opt-in per-item `didDismiss` callback for down-crossings, paired with the existing `didTrack` for start/end signal modeling.
 
 ## Basic usages
 
@@ -103,6 +104,34 @@ let tracker = SushiBeltTracker(
  trackerItemDiffChecker: CustomSushiBeltTrackerItemDiffChecker()
 )
 ```
+
+### Symmetric threshold tracking with `tracksDismiss`
+
+By default, items follow the sticky model: `didTrack` fires once when the ratio first crosses the threshold, and `isTracked` stays `true` until the item leaves the visible set.
+
+For symmetric "above/below" signaling (e.g. viewable impression start/end pairs, time-in-view), register items with `tracksDismiss: true`. The tracker then re-evaluates the ratio every tick and fires a `didDismiss` callback whenever the ratio drops below the threshold — pairing naturally with `didTrack` on subsequent up-crossings.
+
+```swift
+let item = SushiBeltTrackerItem(
+  id: .index(0),
+  rect: someRect,
+  tracksDismiss: true
+)
+
+extension SomeObject: SushiBeltTrackerDelegate {
+
+  func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    // ratio crossed up — start of a visible session
+  }
+
+  func didDismiss(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    // ratio crossed down, OR the item left the set while above threshold
+    // — end of the visible session, paired with the prior didTrack
+  }
+}
+```
+
+`didDismiss` has a default no-op via protocol extension, so existing delegate conformances remain source-compatible. The flag is per-item, so a single tracker can mix sticky and symmetric items.
 
 ### VisibleRatioCalculator
 Default visible ratio clculator will calculate with CGRect.intersection with scrollDirection. If you wanna make a custom visible ratio calculation logics. you can make a custom visible ratio calculator with SushiBeltTrackerItemDiffChecker interface. you just inherts it!

--- a/Sources/SushiBelt/SushiBeltTracker.swift
+++ b/Sources/SushiBelt/SushiBeltTracker.swift
@@ -68,35 +68,41 @@ extension SushiBeltTracker {
     }
             
     items.forEach { item in
-      // early exit
-      if item.isTracked && self.debugger == nil {
+      // early exit — symmetric (tracksDismiss == true) items must be
+      // re-evaluated every tick to detect down-crossings of the threshold
+      if item.isTracked && !item.tracksDismiss && self.debugger == nil {
         return
       }
-      
+
       guard let currentVisibleRatio = self.visibleRatioCalculator.visibleRatio(
         item: item,
         trackingRect: trackingRect
       ) else {
         return
       }
-      
+
       let objectiveVisibleRatio = self.objectiveVisibleRatio(item: item)
-      
+
       let isTracked: Bool = currentVisibleRatio >= objectiveVisibleRatio
       let shouldSendWillBeginTracking: Bool = !item.isTracked && isTracked
-      
+      let shouldSendDidDismiss: Bool = item.tracksDismiss && item.isTracked && !isTracked
+
       var mutableItem = item
       mutableItem.currentVisibleRatio = currentVisibleRatio
       mutableItem.objectiveVisibleRatio = objectiveVisibleRatio
-      
-      /// delegate willBeginTracking
+
       if shouldSendWillBeginTracking {
         mutableItem.isTracked = true
         self.delegate?.didTrack(self, item: mutableItem)
+      } else if shouldSendDidDismiss {
+        mutableItem.isTracked = false
+        self.delegate?.didDismiss(self, item: mutableItem)
       }
-      
+
       /// update cached item
-      guard shouldSendWillBeginTracking || self.debugger != nil else { return }
+      guard shouldSendWillBeginTracking
+              || shouldSendDidDismiss
+              || self.debugger != nil else { return }
       self.cachedItems.update(with: mutableItem)
     }
   }

--- a/Sources/SushiBelt/SushiBeltTracker.swift
+++ b/Sources/SushiBelt/SushiBeltTracker.swift
@@ -47,8 +47,9 @@ public final class SushiBeltTracker {
     self.cachedItems = result.calculationTargetedItems
     self.willBeginTracking(items: result.newItems)
     self.checkBeginTrackingItems(items: self.cachedItems)
+    self.didDismissEndedItems(items: result.endedItems)
     self.didEndTracking(items: result.endedItems)
-    
+
     self.debuggingIfNeeded()
   }
   
@@ -130,6 +131,17 @@ extension SushiBeltTracker {
     items.forEach {
       self.delegate?.didEndTracking(self, item: $0)
     }
+  }
+
+  /// Fires `didDismiss` for tracksDismiss items that leave the tracked set
+  /// while still being tracked (isTracked == true). Invoked before
+  /// `didEndTracking` so that the consumer sees a dismiss → end pair in
+  /// natural order. Sticky items (tracksDismiss == false) are filtered out
+  /// and continue to follow the existing end-only behavior.
+  private func didDismissEndedItems(items: Set<SushiBeltTrackerItem>) {
+    items
+      .filter { $0.tracksDismiss && $0.isTracked }
+      .forEach { self.delegate?.didDismiss(self, item: $0) }
   }
   
   private func objectiveVisibleRatio(item: SushiBeltTrackerItem) -> CGFloat {

--- a/Sources/SushiBelt/SushiBeltTracker.swift
+++ b/Sources/SushiBelt/SushiBeltTracker.swift
@@ -47,7 +47,7 @@ public final class SushiBeltTracker {
     self.cachedItems = result.calculationTargetedItems
     self.willBeginTracking(items: result.newItems)
     self.checkBeginTrackingItems(items: self.cachedItems)
-    self.didDismissEndedItems(items: result.endedItems)
+    self.didExitEndedItems(items: result.endedItems)
     self.didEndTracking(items: result.endedItems)
 
     self.debuggingIfNeeded()
@@ -69,9 +69,9 @@ extension SushiBeltTracker {
     }
             
     items.forEach { item in
-      // early exit — symmetric (tracksDismiss == true) items must be
+      // early exit — symmetric (tracksExit == true) items must be
       // re-evaluated every tick to detect down-crossings of the threshold
-      if item.isTracked && !item.tracksDismiss && self.debugger == nil {
+      if item.isTracked && !item.tracksExit && self.debugger == nil {
         return
       }
 
@@ -85,24 +85,24 @@ extension SushiBeltTracker {
       let objectiveVisibleRatio = self.objectiveVisibleRatio(item: item)
 
       let isTracked: Bool = currentVisibleRatio >= objectiveVisibleRatio
-      let shouldSendWillBeginTracking: Bool = !item.isTracked && isTracked
-      let shouldSendDidDismiss: Bool = item.tracksDismiss && item.isTracked && !isTracked
+      let shouldSendDidEnter: Bool = !item.isTracked && isTracked
+      let shouldSendDidExit: Bool = item.tracksExit && item.isTracked && !isTracked
 
       var mutableItem = item
       mutableItem.currentVisibleRatio = currentVisibleRatio
       mutableItem.objectiveVisibleRatio = objectiveVisibleRatio
 
-      if shouldSendWillBeginTracking {
+      if shouldSendDidEnter {
         mutableItem.isTracked = true
-        self.delegate?.didTrack(self, item: mutableItem)
-      } else if shouldSendDidDismiss {
+        self.delegate?.didEnter(self, item: mutableItem)
+      } else if shouldSendDidExit {
         mutableItem.isTracked = false
-        self.delegate?.didDismiss(self, item: mutableItem)
+        self.delegate?.didExit(self, item: mutableItem)
       }
 
       /// update cached item
-      guard shouldSendWillBeginTracking
-              || shouldSendDidDismiss
+      guard shouldSendDidEnter
+              || shouldSendDidExit
               || self.debugger != nil else { return }
       self.cachedItems.update(with: mutableItem)
     }
@@ -133,15 +133,15 @@ extension SushiBeltTracker {
     }
   }
 
-  /// Fires `didDismiss` for tracksDismiss items that leave the tracked set
+  /// Fires `didExit` for tracksExit items that leave the tracked set
   /// while still being tracked (isTracked == true). Invoked before
-  /// `didEndTracking` so that the consumer sees a dismiss → end pair in
-  /// natural order. Sticky items (tracksDismiss == false) are filtered out
+  /// `didEndTracking` so that the consumer sees an exit → end pair in
+  /// natural order. Sticky items (tracksExit == false) are filtered out
   /// and continue to follow the existing end-only behavior.
-  private func didDismissEndedItems(items: Set<SushiBeltTrackerItem>) {
+  private func didExitEndedItems(items: Set<SushiBeltTrackerItem>) {
     items
-      .filter { $0.tracksDismiss && $0.isTracked }
-      .forEach { self.delegate?.didDismiss(self, item: $0) }
+      .filter { $0.tracksExit && $0.isTracked }
+      .forEach { self.delegate?.didExit(self, item: $0) }
   }
   
   private func objectiveVisibleRatio(item: SushiBeltTrackerItem) -> CGFloat {

--- a/Sources/SushiBelt/SushiBeltTrackerDelegate.swift
+++ b/Sources/SushiBelt/SushiBeltTrackerDelegate.swift
@@ -10,19 +10,25 @@ import UIKit
 
 public protocol SushiBeltTrackerDelegate: AnyObject {
   func willBeginTracking(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem)
-  func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem)
+
+  /// Called when an item's visible ratio crosses up to meet the threshold
+  /// (`isTracked` becomes `true`). For sticky items (`tracksExit == false`)
+  /// this fires once; for symmetric items (`tracksExit == true`) it fires
+  /// again on every up-crossing after a prior `didExit`.
+  func didEnter(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem)
+
   func didEndTracking(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem)
 
-  /// Called when an item with `tracksDismiss == true` stops meeting the
+  /// Called when an item with `tracksExit == true` stops meeting the
   /// visibility threshold while still being tracked. This is the symmetric
-  /// counterpart to `didTrack`, fired on down-crossings of the threshold.
+  /// counterpart to `didEnter`, fired on down-crossings of the threshold.
   ///
   /// Default implementation is a no-op, so existing delegate conformances
-  /// compile without changes. Items registered with `tracksDismiss == false`
+  /// compile without changes. Items registered with `tracksExit == false`
   /// (the default) never trigger this callback.
-  func didDismiss(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem)
+  func didExit(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem)
 }
 
 extension SushiBeltTrackerDelegate {
-  public func didDismiss(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {}
+  public func didExit(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {}
 }

--- a/Sources/SushiBelt/SushiBeltTrackerDelegate.swift
+++ b/Sources/SushiBelt/SushiBeltTrackerDelegate.swift
@@ -12,4 +12,17 @@ public protocol SushiBeltTrackerDelegate: AnyObject {
   func willBeginTracking(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem)
   func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem)
   func didEndTracking(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem)
+
+  /// Called when an item with `tracksDismiss == true` stops meeting the
+  /// visibility threshold while still being tracked. This is the symmetric
+  /// counterpart to `didTrack`, fired on down-crossings of the threshold.
+  ///
+  /// Default implementation is a no-op, so existing delegate conformances
+  /// compile without changes. Items registered with `tracksDismiss == false`
+  /// (the default) never trigger this callback.
+  func didDismiss(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem)
+}
+
+extension SushiBeltTrackerDelegate {
+  public func didDismiss(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {}
 }

--- a/Sources/SushiBelt/SushiBeltTrackerItem.swift
+++ b/Sources/SushiBelt/SushiBeltTrackerItem.swift
@@ -44,12 +44,12 @@ public struct SushiBeltTrackerItem {
   public private(set) var timestamp: Date
 
   /// When `true`, the tracker re-evaluates this item's ratio on every tick
-  /// and fires `didDismiss(_:item:)` when ratio drops below the threshold
+  /// and fires `didExit(_:item:)` when ratio drops below the threshold
   /// (without the item leaving the tracked set). When `false` (default),
-  /// the item follows the sticky behavior: `didTrack` fires once on the
+  /// the item follows the sticky behavior: `didEnter` fires once on the
   /// first up-crossing and `isTracked` stays `true` until the item leaves
   /// the set.
-  public let tracksDismiss: Bool
+  public let tracksExit: Bool
 
   var isTracked: Bool = false
   var currentVisibleRatio: CGFloat = 0.0
@@ -58,11 +58,11 @@ public struct SushiBeltTrackerItem {
   public init(
     id: Identifier,
     rect: SushiBeltTrackerItemRect,
-    tracksDismiss: Bool = false
+    tracksExit: Bool = false
   ) {
     self.id = id
     self.rect = rect
-    self.tracksDismiss = tracksDismiss
+    self.tracksExit = tracksExit
     self.timestamp = Date()
   }
   

--- a/Sources/SushiBelt/SushiBeltTrackerItem.swift
+++ b/Sources/SushiBelt/SushiBeltTrackerItem.swift
@@ -39,16 +39,30 @@ public struct SushiBeltTrackerItem {
   public var status: SushiBeltTrackerItemStatus {
     return self.isTracked ? .tracked : .tracking
   }
-  
+
   public var rect: SushiBeltTrackerItemRect
   public private(set) var timestamp: Date
+
+  /// When `true`, the tracker re-evaluates this item's ratio on every tick
+  /// and fires `didDismiss(_:item:)` when ratio drops below the threshold
+  /// (without the item leaving the tracked set). When `false` (default),
+  /// the item follows the sticky behavior: `didTrack` fires once on the
+  /// first up-crossing and `isTracked` stays `true` until the item leaves
+  /// the set.
+  public let tracksDismiss: Bool
+
   var isTracked: Bool = false
   var currentVisibleRatio: CGFloat = 0.0
   var objectiveVisibleRatio: CGFloat = 0.0
-  
-  public init(id: Identifier, rect: SushiBeltTrackerItemRect) {
+
+  public init(
+    id: Identifier,
+    rect: SushiBeltTrackerItemRect,
+    tracksDismiss: Bool = false
+  ) {
     self.id = id
     self.rect = rect
+    self.tracksDismiss = tracksDismiss
     self.timestamp = Date()
   }
   

--- a/Tests/SushiBeltTests/SushiBeltTrackerItemTests.swift
+++ b/Tests/SushiBeltTests/SushiBeltTrackerItemTests.swift
@@ -264,8 +264,42 @@ extension SushiBeltTrackerItemTests {
     
     // when
     let isEqual = lhs == rhs
-    
+
     // then
     XCTAssertFalse(isEqual)
+  }
+}
+
+// MARK: - tracksDismiss
+
+extension SushiBeltTrackerItemTests {
+
+  func test_init_tracksDismiss_default_is_false() {
+    let item = SushiBeltTrackerItem(id: .index(1), rect: .init(frame: .zero))
+    XCTAssertFalse(item.tracksDismiss)
+  }
+
+  func test_init_tracksDismiss_explicit_true_is_preserved() {
+    let item = SushiBeltTrackerItem(
+      id: .index(1),
+      rect: .init(frame: .zero),
+      tracksDismiss: true
+    )
+    XCTAssertTrue(item.tracksDismiss)
+  }
+
+  func test_equality_ignores_tracksDismiss() {
+    let sticky = SushiBeltTrackerItem(
+      id: .index(1),
+      rect: .init(frame: .zero)
+    )
+    let symmetric = SushiBeltTrackerItem(
+      id: .index(1),
+      rect: .init(frame: .zero),
+      tracksDismiss: true
+    )
+
+    XCTAssertEqual(sticky, symmetric)
+    XCTAssertEqual(sticky.hashValue, symmetric.hashValue)
   }
 }

--- a/Tests/SushiBeltTests/SushiBeltTrackerItemTests.swift
+++ b/Tests/SushiBeltTests/SushiBeltTrackerItemTests.swift
@@ -270,25 +270,25 @@ extension SushiBeltTrackerItemTests {
   }
 }
 
-// MARK: - tracksDismiss
+// MARK: - tracksExit
 
 extension SushiBeltTrackerItemTests {
 
-  func test_init_tracksDismiss_default_is_false() {
+  func test_init_tracksExit_default_is_false() {
     let item = SushiBeltTrackerItem(id: .index(1), rect: .init(frame: .zero))
-    XCTAssertFalse(item.tracksDismiss)
+    XCTAssertFalse(item.tracksExit)
   }
 
-  func test_init_tracksDismiss_explicit_true_is_preserved() {
+  func test_init_tracksExit_explicit_true_is_preserved() {
     let item = SushiBeltTrackerItem(
       id: .index(1),
       rect: .init(frame: .zero),
-      tracksDismiss: true
+      tracksExit: true
     )
-    XCTAssertTrue(item.tracksDismiss)
+    XCTAssertTrue(item.tracksExit)
   }
 
-  func test_equality_ignores_tracksDismiss() {
+  func test_equality_ignores_tracksExit() {
     let sticky = SushiBeltTrackerItem(
       id: .index(1),
       rect: .init(frame: .zero)
@@ -296,7 +296,7 @@ extension SushiBeltTrackerItemTests {
     let symmetric = SushiBeltTrackerItem(
       id: .index(1),
       rect: .init(frame: .zero),
-      tracksDismiss: true
+      tracksExit: true
     )
 
     XCTAssertEqual(sticky, symmetric)

--- a/Tests/SushiBeltTests/SushiBeltTrackerTests.swift
+++ b/Tests/SushiBeltTests/SushiBeltTrackerTests.swift
@@ -331,6 +331,108 @@ extension SushiBeltTrackerTests {
     XCTAssertEqual(tracker.cachedItems.first?.isTracked, false)
   }
 
+  /// Tracked symmetric item leaves the visible set entirely. `didDismiss`
+  /// must fire (surfacing the down transition) and `didEndTracking` must
+  /// still fire for the existing consumers — both for the same item.
+  func test_symmetric_setRemoval_fires_didDismiss_and_didEndTracking() {
+    // given — symmetric tracked item cached, then disappears from new tick
+    let tracker = self.createTracker()
+    let item = SushiBeltTrackerItem(
+      id: .index(1),
+      rect: .init(x: 0.0, y: 100.0, width: 100.0, height: 100.0),
+      tracksDismiss: true
+    ).tracked()
+
+    tracker.cachedItems = .init([item])
+
+    // when — empty input means this item is in endedItems
+    tracker.calculateItemsIfNeeded(items: [])
+
+    // then
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 1)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.first?.id, .index(1))
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEndTrackingItems.count, 1)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEndTrackingItems.first?.id, .index(1))
+  }
+
+  /// Symmetric item that was never tracked (isTracked == false) leaves the
+  /// set. No didDismiss should fire — there is no down transition to surface.
+  func test_symmetric_setRemoval_no_didDismiss_when_not_tracked() {
+    // given
+    let tracker = self.createTracker()
+    let item = SushiBeltTrackerItem(
+      id: .index(1),
+      rect: .init(x: 0.0, y: 100.0, width: 100.0, height: 100.0),
+      tracksDismiss: true
+    )  // isTracked stays false
+
+    tracker.cachedItems = .init([item])
+
+    // when
+    tracker.calculateItemsIfNeeded(items: [])
+
+    // then
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 0)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEndTrackingItems.count, 1)
+  }
+
+  /// Sticky item leaves the set while tracked. Only didEndTracking fires —
+  /// the new didDismiss path must never apply to sticky items.
+  func test_sticky_setRemoval_only_didEndTracking() {
+    // given
+    let tracker = self.createTracker()
+    let item = SushiBeltTrackerItem(
+      id: .index(1),
+      rect: .init(x: 0.0, y: 100.0, width: 100.0, height: 100.0)
+    ).tracked()
+
+    tracker.cachedItems = .init([item])
+
+    // when
+    tracker.calculateItemsIfNeeded(items: [])
+
+    // then
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 0)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEndTrackingItems.count, 1)
+  }
+
+  /// Sticky and symmetric items in the same tracker — both currently tracked,
+  /// both drop below threshold in the same tick. Only the symmetric item
+  /// triggers didDismiss; the sticky item keeps its tracked state.
+  func test_mixed_mode_items_are_independent() {
+    // given
+    let tracker = self.createTracker()
+    self.sushiBeltTrackerDataSource.trackingRectStub = .init(x: 0.0, y: 0.0, width: 100.0, height: 100.0)
+    self.sushiBeltTrackerDataSource.visibleRatioForItemStub = 0.5
+
+    let belowFrame = CGRect(x: 0.0, y: 80.0, width: 100.0, height: 100.0)   // ratio 0.2
+
+    let sticky = SushiBeltTrackerItem(
+      id: .index(1),
+      rect: .init(frame: .zero)
+    ).tracked().frameInWindow(belowFrame)
+
+    let symmetric = SushiBeltTrackerItem(
+      id: .index(2),
+      rect: .init(frame: .zero),
+      tracksDismiss: true
+    ).tracked().frameInWindow(belowFrame)
+
+    tracker.cachedItems = .init([sticky, symmetric])
+
+    // when
+    tracker.checkBeginTrackingItems(items: .init([sticky, symmetric]))
+
+    // then — only the symmetric item fires didDismiss; sticky stays tracked
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 1)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.first?.id, .index(2))
+
+    let stickyAfter    = tracker.cachedItems.first(where: { $0.id == .index(1) })
+    let symmetricAfter = tracker.cachedItems.first(where: { $0.id == .index(2) })
+    XCTAssertEqual(stickyAfter?.isTracked, true)
+    XCTAssertEqual(symmetricAfter?.isTracked, false)
+  }
+
   /// Symmetric item that dipped below threshold (didDismiss fired) must
   /// receive didTrack again when it returns above threshold — verifying that
   /// isTracked is truly live (not sticky) under tracksDismiss == true.

--- a/Tests/SushiBeltTests/SushiBeltTrackerTests.swift
+++ b/Tests/SushiBeltTests/SushiBeltTrackerTests.swift
@@ -247,3 +247,126 @@ extension SushiBeltTrackerTests {
     XCTAssertEqual(self.sushiBeltTrackerDelegate.didEndTrackingItems.count, 1)
   }
 }
+
+// MARK: - tracksDismiss (symmetric tracking)
+
+extension SushiBeltTrackerTests {
+
+  /// Sticky items (tracksDismiss == false) keep the early-exit path even when
+  /// the live ratio drops below the threshold. didDismiss must never fire and
+  /// isTracked must stay true.
+  func test_sticky_no_didDismiss_after_down_cross() {
+    // given — tracked sticky item, now positioned below threshold
+    let tracker = self.createTracker()
+    self.sushiBeltTrackerDataSource.trackingRectStub = .init(x: 0.0, y: 0.0, width: 100.0, height: 100.0)
+    self.sushiBeltTrackerDataSource.visibleRatioForItemStub = 0.5
+
+    let item = SushiBeltTrackerItem(
+      id: .index(1),
+      rect: .init(frame: .zero)
+    )
+      .tracked()
+      .frameInWindow(.init(x: 0.0, y: 80.0, width: 100.0, height: 100.0))  // ratio 0.2 < 0.5
+
+    tracker.cachedItems = .init([item])
+
+    // when
+    tracker.checkBeginTrackingItems(items: .init([item]))
+
+    // then
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.count, 0)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 0)
+    XCTAssertEqual(tracker.cachedItems.first?.isTracked, true)
+  }
+
+  /// Symmetric item crosses the threshold up → didTrack fires and isTracked
+  /// is set to true. Mirrors the sticky up-cross path.
+  func test_symmetric_didTrack_on_up_cross() {
+    // given
+    let tracker = self.createTracker()
+    self.sushiBeltTrackerDataSource.trackingRectStub = .init(x: 0.0, y: 0.0, width: 100.0, height: 100.0)
+    self.sushiBeltTrackerDataSource.visibleRatioForItemStub = 0.5
+
+    let item = SushiBeltTrackerItem(
+      id: .index(1),
+      rect: .init(frame: .zero),
+      tracksDismiss: true
+    ).frameInWindow(.init(x: 0.0, y: 0.0, width: 100.0, height: 100.0))   // ratio 1.0
+
+    tracker.cachedItems = .init([item])
+
+    // when
+    tracker.checkBeginTrackingItems(items: .init([item]))
+
+    // then
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.count, 1)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 0)
+    XCTAssertEqual(tracker.cachedItems.first?.isTracked, true)
+  }
+
+  /// Tracked symmetric item drops below threshold while still in the set →
+  /// didDismiss fires and isTracked flips back to false.
+  func test_symmetric_didDismiss_on_down_cross_while_in_set() {
+    // given — tracked symmetric item, ratio now below threshold
+    let tracker = self.createTracker()
+    self.sushiBeltTrackerDataSource.trackingRectStub = .init(x: 0.0, y: 0.0, width: 100.0, height: 100.0)
+    self.sushiBeltTrackerDataSource.visibleRatioForItemStub = 0.5
+
+    let item = SushiBeltTrackerItem(
+      id: .index(1),
+      rect: .init(frame: .zero),
+      tracksDismiss: true
+    )
+      .tracked()
+      .frameInWindow(.init(x: 0.0, y: 80.0, width: 100.0, height: 100.0))  // ratio 0.2 < 0.5
+
+    tracker.cachedItems = .init([item])
+
+    // when
+    tracker.checkBeginTrackingItems(items: .init([item]))
+
+    // then
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.count, 0)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 1)
+    XCTAssertEqual(tracker.cachedItems.first?.isTracked, false)
+  }
+
+  /// Symmetric item that dipped below threshold (didDismiss fired) must
+  /// receive didTrack again when it returns above threshold — verifying that
+  /// isTracked is truly live (not sticky) under tracksDismiss == true.
+  func test_symmetric_didTrack_fires_again_on_reentry() {
+    // given
+    let tracker = self.createTracker()
+    self.sushiBeltTrackerDataSource.trackingRectStub = .init(x: 0.0, y: 0.0, width: 100.0, height: 100.0)
+    self.sushiBeltTrackerDataSource.visibleRatioForItemStub = 0.5
+
+    let aboveFrame = CGRect(x: 0.0, y: 0.0, width: 100.0, height: 100.0)   // ratio 1.0
+    let belowFrame = CGRect(x: 0.0, y: 80.0, width: 100.0, height: 100.0)  // ratio 0.2
+
+    let baseItem = SushiBeltTrackerItem(
+      id: .index(1),
+      rect: .init(frame: .zero),
+      tracksDismiss: true
+    )
+
+    // tick 1 — above threshold → didTrack
+    let tick1 = baseItem.frameInWindow(aboveFrame)
+    tracker.cachedItems = .init([tick1])
+    tracker.checkBeginTrackingItems(items: .init([tick1]))
+
+    // tick 2 — dropped below threshold → didDismiss
+    let tick2 = tracker.cachedItems.first!.frameInWindow(belowFrame)
+    tracker.cachedItems = .init([tick2])
+    tracker.checkBeginTrackingItems(items: .init([tick2]))
+
+    // tick 3 — back above threshold → didTrack again
+    let tick3 = tracker.cachedItems.first!.frameInWindow(aboveFrame)
+    tracker.cachedItems = .init([tick3])
+    tracker.checkBeginTrackingItems(items: .init([tick3]))
+
+    // then
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.count, 2)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 1)
+    XCTAssertEqual(tracker.cachedItems.first?.isTracked, true)
+  }
+}

--- a/Tests/SushiBeltTests/SushiBeltTrackerTests.swift
+++ b/Tests/SushiBeltTests/SushiBeltTrackerTests.swift
@@ -116,7 +116,7 @@ extension SushiBeltTrackerTests {
     XCTAssertEqual(trackedItems.count, 1)
   }
   
-  func test_checkBeginTrackingItems_should_call_didTrack() {
+  func test_checkBeginTrackingItems_should_call_didEnter() {
     // given
     let tracker = self.createTracker()
     let items = [
@@ -151,14 +151,14 @@ extension SushiBeltTrackerTests {
     // then
     let trackedItems = tracker.cachedItems.filter({ $0.isTracked })
     XCTAssertEqual(trackedItems.count, 1)
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.count, 1)
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.first?.currentVisibleRatio, 0.8)
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.first?.objectiveVisibleRatio, 0.5)
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.first?.isTracked, true)
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.first?.id, .index(2))
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEnterItems.count, 1)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEnterItems.first?.currentVisibleRatio, 0.8)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEnterItems.first?.objectiveVisibleRatio, 0.5)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEnterItems.first?.isTracked, true)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEnterItems.first?.id, .index(2))
   }
   
-  func test_checkBeginTrackingItems_should_not_call_didTrack_on_already_tracked() {
+  func test_checkBeginTrackingItems_should_not_call_didEnter_on_already_tracked() {
     // given
     let tracker = self.createTracker()
     let items = [
@@ -193,7 +193,7 @@ extension SushiBeltTrackerTests {
     // then
     let trackedItems = tracker.cachedItems.filter({ $0.isTracked })
     XCTAssertEqual(trackedItems.count, 1)
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.isEmpty, true)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEnterItems.isEmpty, true)
   }
 }
 
@@ -248,14 +248,14 @@ extension SushiBeltTrackerTests {
   }
 }
 
-// MARK: - tracksDismiss (symmetric tracking)
+// MARK: - tracksExit (symmetric tracking)
 
 extension SushiBeltTrackerTests {
 
-  /// Sticky items (tracksDismiss == false) keep the early-exit path even when
-  /// the live ratio drops below the threshold. didDismiss must never fire and
+  /// Sticky items (tracksExit == false) keep the early-exit path even when
+  /// the live ratio drops below the threshold. didExit must never fire and
   /// isTracked must stay true.
-  func test_sticky_no_didDismiss_after_down_cross() {
+  func test_sticky_no_didExit_after_down_cross() {
     // given — tracked sticky item, now positioned below threshold
     let tracker = self.createTracker()
     self.sushiBeltTrackerDataSource.trackingRectStub = .init(x: 0.0, y: 0.0, width: 100.0, height: 100.0)
@@ -274,14 +274,14 @@ extension SushiBeltTrackerTests {
     tracker.checkBeginTrackingItems(items: .init([item]))
 
     // then
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.count, 0)
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 0)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEnterItems.count, 0)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didExitItems.count, 0)
     XCTAssertEqual(tracker.cachedItems.first?.isTracked, true)
   }
 
-  /// Symmetric item crosses the threshold up → didTrack fires and isTracked
+  /// Symmetric item crosses the threshold up → didEnter fires and isTracked
   /// is set to true. Mirrors the sticky up-cross path.
-  func test_symmetric_didTrack_on_up_cross() {
+  func test_symmetric_didEnter_on_up_cross() {
     // given
     let tracker = self.createTracker()
     self.sushiBeltTrackerDataSource.trackingRectStub = .init(x: 0.0, y: 0.0, width: 100.0, height: 100.0)
@@ -290,7 +290,7 @@ extension SushiBeltTrackerTests {
     let item = SushiBeltTrackerItem(
       id: .index(1),
       rect: .init(frame: .zero),
-      tracksDismiss: true
+      tracksExit: true
     ).frameInWindow(.init(x: 0.0, y: 0.0, width: 100.0, height: 100.0))   // ratio 1.0
 
     tracker.cachedItems = .init([item])
@@ -299,14 +299,14 @@ extension SushiBeltTrackerTests {
     tracker.checkBeginTrackingItems(items: .init([item]))
 
     // then
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.count, 1)
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 0)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEnterItems.count, 1)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didExitItems.count, 0)
     XCTAssertEqual(tracker.cachedItems.first?.isTracked, true)
   }
 
   /// Tracked symmetric item drops below threshold while still in the set →
-  /// didDismiss fires and isTracked flips back to false.
-  func test_symmetric_didDismiss_on_down_cross_while_in_set() {
+  /// didExit fires and isTracked flips back to false.
+  func test_symmetric_didExit_on_down_cross_while_in_set() {
     // given — tracked symmetric item, ratio now below threshold
     let tracker = self.createTracker()
     self.sushiBeltTrackerDataSource.trackingRectStub = .init(x: 0.0, y: 0.0, width: 100.0, height: 100.0)
@@ -315,7 +315,7 @@ extension SushiBeltTrackerTests {
     let item = SushiBeltTrackerItem(
       id: .index(1),
       rect: .init(frame: .zero),
-      tracksDismiss: true
+      tracksExit: true
     )
       .tracked()
       .frameInWindow(.init(x: 0.0, y: 80.0, width: 100.0, height: 100.0))  // ratio 0.2 < 0.5
@@ -326,21 +326,21 @@ extension SushiBeltTrackerTests {
     tracker.checkBeginTrackingItems(items: .init([item]))
 
     // then
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.count, 0)
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 1)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEnterItems.count, 0)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didExitItems.count, 1)
     XCTAssertEqual(tracker.cachedItems.first?.isTracked, false)
   }
 
-  /// Tracked symmetric item leaves the visible set entirely. `didDismiss`
+  /// Tracked symmetric item leaves the visible set entirely. `didExit`
   /// must fire (surfacing the down transition) and `didEndTracking` must
   /// still fire for the existing consumers — both for the same item.
-  func test_symmetric_setRemoval_fires_didDismiss_and_didEndTracking() {
+  func test_symmetric_setRemoval_fires_didExit_and_didEndTracking() {
     // given — symmetric tracked item cached, then disappears from new tick
     let tracker = self.createTracker()
     let item = SushiBeltTrackerItem(
       id: .index(1),
       rect: .init(x: 0.0, y: 100.0, width: 100.0, height: 100.0),
-      tracksDismiss: true
+      tracksExit: true
     ).tracked()
 
     tracker.cachedItems = .init([item])
@@ -349,21 +349,21 @@ extension SushiBeltTrackerTests {
     tracker.calculateItemsIfNeeded(items: [])
 
     // then
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 1)
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.first?.id, .index(1))
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didExitItems.count, 1)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didExitItems.first?.id, .index(1))
     XCTAssertEqual(self.sushiBeltTrackerDelegate.didEndTrackingItems.count, 1)
     XCTAssertEqual(self.sushiBeltTrackerDelegate.didEndTrackingItems.first?.id, .index(1))
   }
 
   /// Symmetric item that was never tracked (isTracked == false) leaves the
-  /// set. No didDismiss should fire — there is no down transition to surface.
-  func test_symmetric_setRemoval_no_didDismiss_when_not_tracked() {
+  /// set. No didExit should fire — there is no down transition to surface.
+  func test_symmetric_setRemoval_no_didExit_when_not_tracked() {
     // given
     let tracker = self.createTracker()
     let item = SushiBeltTrackerItem(
       id: .index(1),
       rect: .init(x: 0.0, y: 100.0, width: 100.0, height: 100.0),
-      tracksDismiss: true
+      tracksExit: true
     )  // isTracked stays false
 
     tracker.cachedItems = .init([item])
@@ -372,12 +372,12 @@ extension SushiBeltTrackerTests {
     tracker.calculateItemsIfNeeded(items: [])
 
     // then
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 0)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didExitItems.count, 0)
     XCTAssertEqual(self.sushiBeltTrackerDelegate.didEndTrackingItems.count, 1)
   }
 
   /// Sticky item leaves the set while tracked. Only didEndTracking fires —
-  /// the new didDismiss path must never apply to sticky items.
+  /// the new didExit path must never apply to sticky items.
   func test_sticky_setRemoval_only_didEndTracking() {
     // given
     let tracker = self.createTracker()
@@ -392,13 +392,13 @@ extension SushiBeltTrackerTests {
     tracker.calculateItemsIfNeeded(items: [])
 
     // then
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 0)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didExitItems.count, 0)
     XCTAssertEqual(self.sushiBeltTrackerDelegate.didEndTrackingItems.count, 1)
   }
 
   /// Sticky and symmetric items in the same tracker — both currently tracked,
   /// both drop below threshold in the same tick. Only the symmetric item
-  /// triggers didDismiss; the sticky item keeps its tracked state.
+  /// triggers didExit; the sticky item keeps its tracked state.
   func test_mixed_mode_items_are_independent() {
     // given
     let tracker = self.createTracker()
@@ -415,7 +415,7 @@ extension SushiBeltTrackerTests {
     let symmetric = SushiBeltTrackerItem(
       id: .index(2),
       rect: .init(frame: .zero),
-      tracksDismiss: true
+      tracksExit: true
     ).tracked().frameInWindow(belowFrame)
 
     tracker.cachedItems = .init([sticky, symmetric])
@@ -423,9 +423,9 @@ extension SushiBeltTrackerTests {
     // when
     tracker.checkBeginTrackingItems(items: .init([sticky, symmetric]))
 
-    // then — only the symmetric item fires didDismiss; sticky stays tracked
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 1)
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.first?.id, .index(2))
+    // then — only the symmetric item fires didExit; sticky stays tracked
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didExitItems.count, 1)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didExitItems.first?.id, .index(2))
 
     let stickyAfter    = tracker.cachedItems.first(where: { $0.id == .index(1) })
     let symmetricAfter = tracker.cachedItems.first(where: { $0.id == .index(2) })
@@ -433,10 +433,10 @@ extension SushiBeltTrackerTests {
     XCTAssertEqual(symmetricAfter?.isTracked, false)
   }
 
-  /// Symmetric item that dipped below threshold (didDismiss fired) must
-  /// receive didTrack again when it returns above threshold — verifying that
-  /// isTracked is truly live (not sticky) under tracksDismiss == true.
-  func test_symmetric_didTrack_fires_again_on_reentry() {
+  /// Symmetric item that dipped below threshold (didExit fired) must
+  /// receive didEnter again when it returns above threshold — verifying that
+  /// isTracked is truly live (not sticky) under tracksExit == true.
+  func test_symmetric_didEnter_fires_again_on_reentry() {
     // given
     let tracker = self.createTracker()
     self.sushiBeltTrackerDataSource.trackingRectStub = .init(x: 0.0, y: 0.0, width: 100.0, height: 100.0)
@@ -448,27 +448,27 @@ extension SushiBeltTrackerTests {
     let baseItem = SushiBeltTrackerItem(
       id: .index(1),
       rect: .init(frame: .zero),
-      tracksDismiss: true
+      tracksExit: true
     )
 
-    // tick 1 — above threshold → didTrack
+    // tick 1 — above threshold → didEnter
     let tick1 = baseItem.frameInWindow(aboveFrame)
     tracker.cachedItems = .init([tick1])
     tracker.checkBeginTrackingItems(items: .init([tick1]))
 
-    // tick 2 — dropped below threshold → didDismiss
+    // tick 2 — dropped below threshold → didExit
     let tick2 = tracker.cachedItems.first!.frameInWindow(belowFrame)
     tracker.cachedItems = .init([tick2])
     tracker.checkBeginTrackingItems(items: .init([tick2]))
 
-    // tick 3 — back above threshold → didTrack again
+    // tick 3 — back above threshold → didEnter again
     let tick3 = tracker.cachedItems.first!.frameInWindow(aboveFrame)
     tracker.cachedItems = .init([tick3])
     tracker.checkBeginTrackingItems(items: .init([tick3]))
 
     // then
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didTrackItems.count, 2)
-    XCTAssertEqual(self.sushiBeltTrackerDelegate.didDismissItems.count, 1)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didEnterItems.count, 2)
+    XCTAssertEqual(self.sushiBeltTrackerDelegate.didExitItems.count, 1)
     XCTAssertEqual(tracker.cachedItems.first?.isTracked, true)
   }
 }

--- a/Tests/SushiBeltTests/TestDoubles/SushiBeltTrackerDelegateSpy.swift
+++ b/Tests/SushiBeltTests/TestDoubles/SushiBeltTrackerDelegateSpy.swift
@@ -16,10 +16,10 @@ final class SushiBeltTrackerDelegateSpy: SushiBeltTrackerDelegate {
     self.willBeginTrackingItems.append(item)
   }
 
-  var didTrackItems: [SushiBeltTrackerItem] = []
+  var didEnterItems: [SushiBeltTrackerItem] = []
 
-  func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
-    self.didTrackItems.append(item)
+  func didEnter(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    self.didEnterItems.append(item)
   }
 
   var didEndTrackingItems: [SushiBeltTrackerItem] = []
@@ -28,10 +28,10 @@ final class SushiBeltTrackerDelegateSpy: SushiBeltTrackerDelegate {
     self.didEndTrackingItems.append(item)
   }
 
-  var didDismissItems: [SushiBeltTrackerItem] = []
+  var didExitItems: [SushiBeltTrackerItem] = []
 
-  func didDismiss(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
-    self.didDismissItems.append(item)
+  func didExit(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    self.didExitItems.append(item)
   }
 
 }

--- a/Tests/SushiBeltTests/TestDoubles/SushiBeltTrackerDelegateSpy.swift
+++ b/Tests/SushiBeltTests/TestDoubles/SushiBeltTrackerDelegateSpy.swift
@@ -23,9 +23,15 @@ final class SushiBeltTrackerDelegateSpy: SushiBeltTrackerDelegate {
   }
 
   var didEndTrackingItems: [SushiBeltTrackerItem] = []
-  
+
   func didEndTracking(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
     self.didEndTrackingItems.append(item)
   }
-  
+
+  var didDismissItems: [SushiBeltTrackerItem] = []
+
+  func didDismiss(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+    self.didDismissItems.append(item)
+  }
+
 }


### PR DESCRIPTION
## Summary

Adds **symmetric threshold tracking** — an opt-in per-item flag (`SushiBeltTrackerItem.tracksExit`) that makes an item fire a `didExit` callback when its visible ratio drops **below** the threshold while still being tracked, and re-fire `didEnter` when it crosses back up.

To give the new down-crossing callback a name that forms a clean symmetric pair, the existing up-crossing callback **`didTrack` is renamed to `didEnter`**. This is the only breaking change; everything else is additive.

This unlocks **start/end pair** signal modeling (e.g. MRC viewable impression `didBecomeVisible` ↔ `didBecomeInvisible`) using a single tracker that can mix sticky (legacy) and symmetric items.

## Motivation

The previous API surfaced only the **up-crossing** of the threshold (`didTrack`, fired once) and **set removal** (`didEndTracking`). It was silent on items that stay in the visible set but drop below the threshold, and on items that dip below and recover. Consumers needing symmetric "above/below threshold" signaling had to re-implement ratio sampling on top of SushiBelt.

## Naming — why `enter`/`exit` (and a breaking rename)

SushiBelt has **two independent axes**, and the new callback belongs to the threshold axis, not set membership:

| Axis | Enters | Leaves |
|---|---|---|
| **Set membership** | `willBeginTracking` | `didEndTracking` |
| **Visibility threshold** | `didEnter` (was `didTrack`) | `didExit` (new) |

When `didExit` fires the item is **still in the set** — only its visible ratio dropped below the threshold (`isTracked: true → false`). So membership-flavored words (`dismiss`, `exit`-as-leaving, `didEndDisplaying`) read as the wrong axis. `enter`/`exit` are true opposites on the threshold axis, and the `…Tracking` suffix keeps the membership callbacks visually distinct.

`track`/`exit` is not a symmetric pair, so `didTrack` is renamed to `didEnter` to complete `didEnter` ↔ `didExit`. (Discussion: thread on `SushiBeltTrackerItem`.)

## API changes

| Location | Change | Kind |
|---|---|---|
| `SushiBeltTrackerDelegate` | `didTrack(_:item:)` → `didEnter(_:item:)` | **Breaking** — renamed, same signature & semantics |
| `SushiBeltTrackerDelegate` | New `didExit(_:item:)` with default no-op via protocol extension | Additive |
| `SushiBeltTrackerItem` | New `let tracksExit: Bool` (default `false`), set via init parameter | Additive |

## Behavior

| Mode | Condition | Behavior |
|---|---|---|
| **Sticky** (default) | `tracksExit == false` | Unchanged — `didEnter` fires once on first up-crossing; `isTracked` stays `true` until the item leaves the set; early-exit preserved for already-tracked items |
| **Symmetric** | `tracksExit == true` | Ratio re-evaluated every tick; `didEnter` fires on up-crossings, `didExit` on down-crossings; `isTracked` flips both ways; on set removal while tracked, `didExit` fires before the existing `didEndTracking` |

`Hashable`/`Equatable` remain id-only — `tracksExit` does not affect item identity.

## Migration (2.x → 3.0)

The `didTrack` → `didEnter` rename is the only breaking change. Rename your delegate method (body unchanged); the compiler flags every call site since `didEnter` has no default implementation. Full guide: [MIGRATION.md](https://github.com/daangn/SushiBelt/blob/feature/jamie/per-item-tracks-dismiss/MIGRATION.md).

```diff
- func didTrack(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
+ func didEnter(_ tracker: SushiBeltTracker, item: SushiBeltTrackerItem) {
    // unchanged body
  }
```

`didExit` and `tracksExit` are additive — no further changes unless you opt into symmetric tracking.

## Tests

All 36 tests pass on the iOS simulator, including the symmetric-tracking suite:

- Sticky: no `didExit` after down-cross (early-exit preserved); set removal emits only `didEndTracking`
- Symmetric: `didEnter` on up-cross; `didExit` on down-cross while in set (`isTracked → false`); `didEnter` fires again on re-entry (3-tick); set removal while tracked emits `didExit` + `didEndTracking`; set removal while untracked emits only `didEndTracking`
- Mixed mode: sticky and symmetric items in one tracker behave independently
- Item: `tracksExit` default/explicit, identity ignores `tracksExit`
